### PR TITLE
Improve error handling defaults and logging robustness

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # What is this?
 
-Handling Operational nad Programmer Errors on NodeJS
+Handling Operational and Programmer Errors on NodeJS
 
 # Installation
 
@@ -9,14 +9,14 @@ Handling Operational nad Programmer Errors on NodeJS
 Then...
 
 ```
-import * as errorHandler from 'error-handler';
+import * as errorHandler from 'error-handler-system';
 
 OR
 
-require('error-handler');
+require('error-handler-system');
 ```
 
-Thats it.
+That's it.
 Join!
 
 link to npm package: `https://www.npmjs.com/package/error-handler-system`

--- a/error-handler.js
+++ b/error-handler.js
@@ -10,13 +10,13 @@ function sendEventsToSentry(err) {
 }
 
 class ErrorHandler {
-  async handleError(err) {
-    await logger.error(
+  handleError(err) {
+    logger.error(
       'Error message from the centralized error-handling component',
       err,
     );
-    await sendMailToAdminIfCritical(err);
-    await sendEventsToSentry(err);
+    sendMailToAdminIfCritical(err);
+    sendEventsToSentry(err);
   }
 
   isTrustedError(error) {

--- a/http-status-code.js
+++ b/http-status-code.js
@@ -73,7 +73,10 @@ class HttpClientErrorStatusCode {
   }
 
   getCode(value) {
-    return this[value];
+    if (Object.prototype.hasOwnProperty.call(this, value)) {
+      return this[value];
+    }
+    return undefined;
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -1,9 +1,7 @@
 const { errorHandler } = require('./error-handler.js');
 
-process.env.NODE_ENV = 'PROD';
-
-process.on('unhandledRejection', (reason, promise) => {
-  throw { reason, promise };
+process.on('unhandledRejection', reason => {
+  throw reason instanceof Error ? reason : new Error(String(reason));
 });
 
 process.on('uncaughtException', error => {

--- a/is-dev.js
+++ b/is-dev.js
@@ -2,17 +2,22 @@ class IsDev {
   constructor() {
     this._default = null;
     this._env = null;
-    this._values = ['develop'];
+    this._values = ['prod', 'production'];
     return this.default;
   }
 
   get default() {
-    this._default = Object.keys(process.env).some(key => {
-      const processEnvKey = process.env[key];
-      const result = this._values.some(v => processEnvKey.toLowerCase() !== v);
-      this._env = result ? { key, value: processEnvKey } : undefined;
-      return result;
-    });
+    const envValue = process.env.NODE_ENV;
+    if (!envValue) {
+      this._default = true;
+      this._env = undefined;
+      return this._default;
+    }
+
+    const normalized = envValue.toLowerCase();
+    const isProd = this._values.some(value => normalized === value);
+    this._default = !isProd;
+    this._env = { key: 'NODE_ENV', value: envValue };
 
     return this._default;
   }

--- a/logger.js
+++ b/logger.js
@@ -1,4 +1,6 @@
 
+const fs = require('fs');
+const path = require('path');
 const winston = require('winston');
 const isDevEnvironment = require('./is-dev.js');
 
@@ -40,8 +42,10 @@ class Logger {
   logger;
 
   constructor() {
+    const logDirectory = path.resolve('logs');
+    fs.mkdirSync(logDirectory, { recursive: true });
     const prodTransport = new winston.transports.File({
-      filename: 'logs/error.log',
+      filename: path.join(logDirectory, 'error.log'),
       level: 'error',
     });
     const transport = new winston.transports.Console({


### PR DESCRIPTION
### Motivation
- Ensure environment detection is deterministic by relying on `NODE_ENV` instead of scanning all `process.env` keys.
- Prevent throwing non-`Error` objects on unhandled promise rejections to make stack traces and crash behavior consistent.
- Make logging robust by ensuring the `logs` directory exists and using platform-safe paths for log files.
- Harden utility lookups and documentation to avoid confusion and accidental misuse.

### Description
- Rewrote environment detection in `is-dev.js` to read `NODE_ENV`, normalize values, set production defaults, and expose the detected env via the existing API.
- Changed `process.on('unhandledRejection', ...)` in `index.js` to rethrow a proper `Error` instance (`throw reason instanceof Error ? reason : new Error(String(reason))`).
- Updated `logger.js` to create the `logs` directory (`fs.mkdirSync(..., { recursive: true })`) and use `path.join`/`path.resolve` for `logs/error.log` so file transport is reliable across platforms.
- Made `error-handler.js` synchronous in its logging calls by removing `async/await` around `logger.error`, and kept subsequent notification calls (`sendMailToAdminIfCritical`, `sendEventsToSentry`) as regular calls.
- Tightened `getCode` in `http-status-code.js` to only return a code when the property is an own property using `Object.prototype.hasOwnProperty.call(this, value)`.
- Fixed typos and corrected import instructions in `README.md` to reference `error-handler-system` and minor grammar fixes.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694e573165b883208fa425f61c61c1ac)